### PR TITLE
openjdk-8: Update patches for patch fuzz for Yocto 4.2 mickledore

### DIFF
--- a/recipes-core/openjdk/patches-openjdk-8/0001-Allow-using-a-system-installed-libjpeg.patch
+++ b/recipes-core/openjdk/patches-openjdk-8/0001-Allow-using-a-system-installed-libjpeg.patch
@@ -1,7 +1,7 @@
-From 21c555306afcc4cab2819adc550f1546f3390d15 Mon Sep 17 00:00:00 2001
+From 74366a35d754d2dacab28d36804b5cde5dec481b Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Andr=C3=A9=20Draszik?= <andre.draszik@jci.com>
 Date: Tue, 27 Feb 2018 13:36:53 +0000
-Subject: [PATCH 01/13] Allow using a system-installed libjpeg
+Subject: [PATCH] Allow using a system-installed libjpeg
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
 Content-Transfer-Encoding: 8bit
@@ -22,12 +22,13 @@ Upstream-Status: Backport
 
 Signed-off-by: André Draszik <andre.draszik@jci.com>
 Signed-off-by: Richard Leitner <richard.leitner@skidata.com>
+
 ---
  common/autoconf/libraries.m4 | 35 ++++++++++++++++++++++++++++++-----
  1 file changed, 30 insertions(+), 5 deletions(-)
 
 diff --git a/common/autoconf/libraries.m4 b/common/autoconf/libraries.m4
-index 6d803f9..d2732eb 100644
+index 6d803f9b..d2732eb8 100644
 --- a/common/autoconf/libraries.m4
 +++ b/common/autoconf/libraries.m4
 @@ -774,11 +774,36 @@ AC_DEFUN_ONCE([LIB_SETUP_MISC_LIBS],
@@ -72,6 +73,3 @@ index 6d803f9..d2732eb 100644
    AC_SUBST(USE_EXTERNAL_LIBJPEG)
  
    ###############################################################################
--- 
-2.26.2
-

--- a/recipes-core/openjdk/patches-openjdk-8/0002-Allow-using-a-system-installed-libpng.patch
+++ b/recipes-core/openjdk/patches-openjdk-8/0002-Allow-using-a-system-installed-libpng.patch
@@ -1,7 +1,7 @@
-From 17413a1bca9a6c27e049122d65b0d4fa291a53ec Mon Sep 17 00:00:00 2001
+From 048b9cb7910cf2f04f73483dd9755aeb50017e6b Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Andr=C3=A9=20Draszik?= <andre.draszik@jci.com>
 Date: Thu, 2 Jan 2020 13:40:50 +0100
-Subject: [PATCH 02/13] Allow using a system-installed libpng
+Subject: [PATCH] Allow using a system-installed libpng
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
 Content-Transfer-Encoding: 8bit
@@ -19,12 +19,13 @@ Upstream-Status: Backport
 
 Signed-off-by: André Draszik <andre.draszik@jci.com>
 Signed-off-by: Richard Leitner <richard.leitner@skidata.com>
+
 ---
  common/autoconf/libraries.m4 | 41 ++++++++++++++++++++++++++++++++++++
  1 file changed, 41 insertions(+)
 
 diff --git a/common/autoconf/libraries.m4 b/common/autoconf/libraries.m4
-index d2732eb..727f018 100644
+index d2732eb8..727f0181 100644
 --- a/common/autoconf/libraries.m4
 +++ b/common/autoconf/libraries.m4
 @@ -843,6 +843,47 @@ AC_DEFUN_ONCE([LIB_SETUP_MISC_LIBS],
@@ -75,6 +76,3 @@ index d2732eb..727f018 100644
    ###############################################################################
    #
    # Check for the zlib library
--- 
-2.26.2
-

--- a/recipes-core/openjdk/patches-openjdk-8/0003-build-fix-build-on-as-needed-toolchains-generic.patch
+++ b/recipes-core/openjdk/patches-openjdk-8/0003-build-fix-build-on-as-needed-toolchains-generic.patch
@@ -1,7 +1,7 @@
-From 770123c9fcc4ab8c8ce8f37cde5afe9c44c7176c Mon Sep 17 00:00:00 2001
+From 34bfdbabf0b2d9b1d0965b5fe362fd9596f58527 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Andr=C3=A9=20Draszik?= <andre.draszik@jci.com>
 Date: Mon, 12 Mar 2018 15:40:58 +0000
-Subject: [PATCH 03/13] build: fix build on --as-needed toolchains (generic)
+Subject: [PATCH] build: fix build on --as-needed toolchains (generic)
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
 Content-Transfer-Encoding: 8bit
@@ -66,12 +66,13 @@ all.
 
 Signed-off-by: André Draszik <andre.draszik@jci.com>
 Signed-off-by: Richard Leitner <richard.leitner@skidata.com>
+
 ---
  make/common/NativeCompilation.gmk | 5 ++---
  1 file changed, 2 insertions(+), 3 deletions(-)
 
 diff --git a/make/common/NativeCompilation.gmk b/make/common/NativeCompilation.gmk
-index d961cf3..92f8033 100644
+index d961cf35..92f8033f 100644
 --- a/make/common/NativeCompilation.gmk
 +++ b/make/common/NativeCompilation.gmk
 @@ -618,9 +618,8 @@ endif # no MacOS X support yet
@@ -86,6 +87,3 @@ index d961cf3..92f8033 100644
          ifneq (,$$($1_GEN_MANIFEST))
  	  $(MT) -nologo -manifest $$($1_GEN_MANIFEST) -outputresource:$$@;#1
          endif
--- 
-2.26.2
-

--- a/recipes-core/openjdk/patches-openjdk-8/0004-don-t-expect-fqpn-for-make.patch
+++ b/recipes-core/openjdk/patches-openjdk-8/0004-don-t-expect-fqpn-for-make.patch
@@ -1,15 +1,16 @@
-From 12dbeed90199730ad56ad842ae53e9d8aa477c0c Mon Sep 17 00:00:00 2001
+From a99cf53a082c1b25f5f7159c65bfd2c27a63fe75 Mon Sep 17 00:00:00 2001
 From: Jens Rehsack <rehsack@gmail.com>
 Date: Thu, 2 Jan 2020 13:42:43 +0100
-Subject: [PATCH 04/13] don't expect fqpn for make
+Subject: [PATCH] don't expect fqpn for make
 
 Signed-off-by: Richard Leitner <richard.leitner@skidata.com>
+
 ---
  common/autoconf/basics.m4 | 8 +++++---
  1 file changed, 5 insertions(+), 3 deletions(-)
 
 diff --git a/common/autoconf/basics.m4 b/common/autoconf/basics.m4
-index 4ee9cdd..c20ea76 100644
+index 4ee9cdd1..c20ea765 100644
 --- a/common/autoconf/basics.m4
 +++ b/common/autoconf/basics.m4
 @@ -740,10 +740,12 @@ AC_DEFUN([BASIC_CHECK_GNU_MAKE],
@@ -28,6 +29,3 @@ index 4ee9cdd..c20ea76 100644
      if test "x$FOUND_MAKE" = x; then
        AC_MSG_ERROR([The specified make (by MAKE=$MAKE) is not GNU make 3.81 or newer.])
      fi
--- 
-2.26.2
-

--- a/recipes-core/openjdk/patches-openjdk-8/0005-autoconf-filter-aclocal-copy-too.patch
+++ b/recipes-core/openjdk/patches-openjdk-8/0005-autoconf-filter-aclocal-copy-too.patch
@@ -1,15 +1,16 @@
-From def92aa795271fa3e6fd36009d89e06009d21c6a Mon Sep 17 00:00:00 2001
+From 37a7b95ab512ddeb635b6b8e23e4bac089ccee38 Mon Sep 17 00:00:00 2001
 From: Jens Rehsack <rehsack@gmail.com>
 Date: Thu, 2 Jan 2020 13:44:25 +0100
-Subject: [PATCH 05/13] autoconf: filter aclocal copy too
+Subject: [PATCH] autoconf: filter aclocal copy too
 
 Signed-off-by: Richard Leitner <richard.leitner@skidata.com>
+
 ---
  common/autoconf/basics.m4 | 1 +
  1 file changed, 1 insertion(+)
 
 diff --git a/common/autoconf/basics.m4 b/common/autoconf/basics.m4
-index c20ea76..8e06cd2 100644
+index c20ea765..8e06cd25 100644
 --- a/common/autoconf/basics.m4
 +++ b/common/autoconf/basics.m4
 @@ -636,6 +636,7 @@ AC_DEFUN_ONCE([BASIC_SETUP_OUTPUT_DIR],
@@ -20,6 +21,3 @@ index c20ea76..8e06cd2 100644
  	      -e 's/ //g' \
            | $TR -d '\n'`
        if test "x$filtered_files" != x; then
--- 
-2.26.2
-

--- a/recipes-core/openjdk/patches-openjdk-8/0006-autoconf-handle-extra-output.patch
+++ b/recipes-core/openjdk/patches-openjdk-8/0006-autoconf-handle-extra-output.patch
@@ -1,19 +1,20 @@
-From ee5e07895570a9ea2ae2490f3b159bde29967238 Mon Sep 17 00:00:00 2001
+From be1397b2106874869eebfc0b21943f1976a97f1b Mon Sep 17 00:00:00 2001
 From: Haiqing Bai <Haiqing.Bai@windriver.com>
 Date: Thu, 2 Jan 2020 13:45:42 +0100
-Subject: [PATCH 06/13] autoconf: handle extra output
+Subject: [PATCH] autoconf: handle extra output
 
 When adding the environment variable JAVA_TOOL_OPTIONS an extra line
 in the output from 'java -version' is produced. As this output is
 parsed by configure script the extra line has to be filtered out.
 
 Signed-off-by: Richard Leitner <richard.leitner@skidata.com>
+
 ---
  common/autoconf/boot-jdk.m4 | 2 +-
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/common/autoconf/boot-jdk.m4 b/common/autoconf/boot-jdk.m4
-index 5be15b8..0d1a6e1 100644
+index 5be15b86..0d1a6e14 100644
 --- a/common/autoconf/boot-jdk.m4
 +++ b/common/autoconf/boot-jdk.m4
 @@ -51,7 +51,7 @@ AC_DEFUN([BOOTJDK_DO_CHECK],
@@ -25,6 +26,3 @@ index 5be15b8..0d1a6e1 100644
  
              # Extra M4 quote needed to protect [] in grep expression.
              [FOUND_VERSION_78=`echo $BOOT_JDK_VERSION | grep  '\"1\.[78]\.'`]
--- 
-2.26.2
-

--- a/recipes-core/openjdk/patches-openjdk-8/0007-fix-assembler-flag-handling-in-makefile.patch
+++ b/recipes-core/openjdk/patches-openjdk-8/0007-fix-assembler-flag-handling-in-makefile.patch
@@ -1,7 +1,7 @@
-From b8d48149b05fcd1a12dce25ffc345b43aaa76f32 Mon Sep 17 00:00:00 2001
+From 2206e1d037359cf4f08a6c7b944d6735b56ea36d Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Erkka=20K=C3=A4=C3=A4ri=C3=A4?= <erkka.kaaria@intel.com>
 Date: Thu, 2 Jan 2020 13:49:02 +0100
-Subject: [PATCH 07/13] fix assembler flag handling in makefile
+Subject: [PATCH] fix assembler flag handling in makefile
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
 Content-Transfer-Encoding: 8bit
@@ -14,12 +14,13 @@ Upstream-Status: Pending
 
 Signed-off-by: Erkka Kääriä <erkka.kaaria@intel.com>
 Signed-off-by: Richard Leitner <richard.leitner@skidata.com>
+
 ---
  make/common/NativeCompilation.gmk | 2 +-
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/make/common/NativeCompilation.gmk b/make/common/NativeCompilation.gmk
-index 92f8033..46a1be9 100644
+index 92f8033f..46a1be91 100644
 --- a/make/common/NativeCompilation.gmk
 +++ b/make/common/NativeCompilation.gmk
 @@ -391,7 +391,7 @@ define SetupNativeCompilation
@@ -31,6 +32,3 @@ index 92f8033..46a1be9 100644
  
    # On windows we need to create a resource file
    ifeq ($(OPENJDK_TARGET_OS), windows)
--- 
-2.26.2
-

--- a/recipes-core/openjdk/patches-openjdk-8/0008-autoconf-fix-shark-build-common.patch
+++ b/recipes-core/openjdk/patches-openjdk-8/0008-autoconf-fix-shark-build-common.patch
@@ -1,15 +1,16 @@
-From c03f916a8a49a3c83f72f28fefa6eab6377b909c Mon Sep 17 00:00:00 2001
+From bc54b9fbe29c524c07377fb8a87922be55c61700 Mon Sep 17 00:00:00 2001
 From: Jens Rehsack <rehsack@gmail.com>
 Date: Thu, 2 Jan 2020 13:51:40 +0100
-Subject: [PATCH 08/13] autoconf: fix shark build (common)
+Subject: [PATCH] autoconf: fix shark build (common)
 
 Signed-off-by: Richard Leitner <richard.leitner@skidata.com>
+
 ---
  common/autoconf/libraries.m4 | 5 +++--
  1 file changed, 3 insertions(+), 2 deletions(-)
 
 diff --git a/common/autoconf/libraries.m4 b/common/autoconf/libraries.m4
-index 727f018..91d2b5c 100644
+index 727f0181..91d2b5ca 100644
 --- a/common/autoconf/libraries.m4
 +++ b/common/autoconf/libraries.m4
 @@ -1079,8 +1079,9 @@ AC_DEFUN_ONCE([LIB_SETUP_STATIC_LINK_LIBSTDCPP],
@@ -32,6 +33,3 @@ index 727f018..91d2b5c 100644
        if echo "${flag}" | grep -q '^-l'; then
          if test "${LLVM_LIBS}" != ""; then
            LLVM_LIBS="${LLVM_LIBS} "
--- 
-2.26.2
-

--- a/recipes-core/openjdk/patches-openjdk-8/0009-prevent-debuginfo-in-favour-of-openembedded-package-.patch
+++ b/recipes-core/openjdk/patches-openjdk-8/0009-prevent-debuginfo-in-favour-of-openembedded-package-.patch
@@ -1,16 +1,16 @@
-From a2a8f8df244efca22da633b676a45d62b2fbb580 Mon Sep 17 00:00:00 2001
+From 038f36c083a83916504b8b59c80099fbeb9a68d6 Mon Sep 17 00:00:00 2001
 From: Jens Rehsack <rehsack@gmail.com>
 Date: Thu, 2 Jan 2020 13:53:50 +0100
-Subject: [PATCH 09/13] prevent debuginfo in favour of openembedded package
- split
+Subject: [PATCH] prevent debuginfo in favour of openembedded package split
 
 Signed-off-by: Richard Leitner <richard.leitner@skidata.com>
+
 ---
  make/common/NativeCompilation.gmk | 122 ------------------------------
  1 file changed, 122 deletions(-)
 
 diff --git a/make/common/NativeCompilation.gmk b/make/common/NativeCompilation.gmk
-index 46a1be9..b4ea2c6 100644
+index 46a1be91..b4ea2c6f 100644
 --- a/make/common/NativeCompilation.gmk
 +++ b/make/common/NativeCompilation.gmk
 @@ -456,67 +456,6 @@ define SetupNativeCompilation
@@ -149,6 +149,3 @@ index 46a1be9..b4ea2c6 100644
        endif
      endif
  
--- 
-2.26.2
-

--- a/recipes-core/openjdk/patches-openjdk-8/0010-autoconf-remove-shell-variables-from-autoheader.patch
+++ b/recipes-core/openjdk/patches-openjdk-8/0010-autoconf-remove-shell-variables-from-autoheader.patch
@@ -1,15 +1,16 @@
-From 8864d47290e9d5563fb8f3ea92639c4accc46fe8 Mon Sep 17 00:00:00 2001
+From b6e88ffb6c4a8d84da643fa9cb29c086f7c02584 Mon Sep 17 00:00:00 2001
 From: Jens Rehsack <rehsack@gmail.com>
 Date: Thu, 2 Jan 2020 13:55:29 +0100
-Subject: [PATCH 10/13] autoconf: remove shell variables from autoheader
+Subject: [PATCH] autoconf: remove shell variables from autoheader
 
 Signed-off-by: Richard Leitner <richard.leitner@skidata.com>
+
 ---
  common/autoconf/basics.m4 | 14 +++++++-------
  1 file changed, 7 insertions(+), 7 deletions(-)
 
 diff --git a/common/autoconf/basics.m4 b/common/autoconf/basics.m4
-index 8e06cd2..c220bba 100644
+index 8e06cd25..c220bba7 100644
 --- a/common/autoconf/basics.m4
 +++ b/common/autoconf/basics.m4
 @@ -661,21 +661,21 @@ AC_DEFUN_ONCE([BASIC_SETUP_OUTPUT_DIR],
@@ -41,6 +42,3 @@ index 8e06cd2..c220bba 100644
  ])
  
  AC_DEFUN_ONCE([BASIC_SETUP_LOGGING],
--- 
-2.26.2
-

--- a/recipes-core/openjdk/patches-openjdk-8/0013-autoconf-remove-Werror.patch
+++ b/recipes-core/openjdk/patches-openjdk-8/0013-autoconf-remove-Werror.patch
@@ -1,7 +1,7 @@
-From 3d7493808f435b70101003534d98e249bf7e734c Mon Sep 17 00:00:00 2001
+From 3a41aceff84ac9c64910f2efbd4bee7c3532c65d Mon Sep 17 00:00:00 2001
 From: Richard Leitner <richard.leitner@skidata.com>
 Date: Wed, 29 Apr 2020 10:15:11 +0200
-Subject: [PATCH 13/13] autoconf: remove Werror
+Subject: [PATCH] autoconf: remove Werror
 
 We don't want to mess around with disabling warnings on new
 compiler versions therefore we remove Werror.
@@ -9,13 +9,14 @@ compiler versions therefore we remove Werror.
 Upstream-Status: Invalid
 
 Signed-off-by: Richard Leitner <richard.leitner@skidata.com>
+
 ---
  common/autoconf/flags.m4               | 12 +++---
  common/autoconf/generated-configure.sh | 56 +++++++++++++-------------
  2 files changed, 34 insertions(+), 34 deletions(-)
 
 diff --git a/common/autoconf/flags.m4 b/common/autoconf/flags.m4
-index 077efa2..b98575a 100644
+index 077efa29..b98575a1 100644
 --- a/common/autoconf/flags.m4
 +++ b/common/autoconf/flags.m4
 @@ -399,7 +399,7 @@ AC_DEFUN_ONCE([FLAGS_SETUP_COMPILER_FLAGS_FOR_JDK],
@@ -63,10 +64,10 @@ index 077efa2..b98575a 100644
    CFLAGS_JDK="${CFLAGS_JDK} ${NO_DELETE_NULL_POINTER_CHECKS_CFLAG} ${NO_LIFETIME_DSE_CFLAG}"
    AC_SUBST([NO_LIFETIME_DSE_CFLAG])
 diff --git a/common/autoconf/generated-configure.sh b/common/autoconf/generated-configure.sh
-index f285a74..31d41b1 100644
+index d57035b0..1953dc4e 100644
 --- a/common/autoconf/generated-configure.sh
 +++ b/common/autoconf/generated-configure.sh
-@@ -41503,12 +41503,12 @@ $as_echo "$ac_cv_c_bigendian" >&6; }
+@@ -41498,12 +41498,12 @@ $as_echo "$ac_cv_c_bigendian" >&6; }
      fi
      CXXSTD_CXXFLAG="-std=gnu++98"
  
@@ -82,7 +83,7 @@ index f285a74..31d41b1 100644
    ac_ext=cpp
  ac_cpp='$CXXCPP $CPPFLAGS'
  ac_compile='$CXX -c $CXXFLAGS $CPPFLAGS conftest.$ac_ext >&5'
-@@ -41659,12 +41659,12 @@ fi
+@@ -41654,12 +41654,12 @@ fi
    NO_DELETE_NULL_POINTER_CHECKS_CFLAG="-fno-delete-null-pointer-checks"
  
  
@@ -98,7 +99,7 @@ index f285a74..31d41b1 100644
    ac_ext=c
  ac_cpp='$CPP $CPPFLAGS'
  ac_compile='$CC -c $CFLAGS $CPPFLAGS conftest.$ac_ext >&5'
-@@ -41699,12 +41699,12 @@ $as_echo "$supports" >&6; }
+@@ -41694,12 +41694,12 @@ $as_echo "$supports" >&6; }
    fi
  
  
@@ -114,7 +115,7 @@ index f285a74..31d41b1 100644
    ac_ext=cpp
  ac_cpp='$CXXCPP $CPPFLAGS'
  ac_compile='$CXX -c $CXXFLAGS $CPPFLAGS conftest.$ac_ext >&5'
-@@ -41738,8 +41738,8 @@ $as_echo "$supports" >&6; }
+@@ -41733,8 +41733,8 @@ $as_echo "$supports" >&6; }
    fi
  
  
@@ -125,7 +126,7 @@ index f285a74..31d41b1 100644
    supports=no
    if test "x$C_COMP_SUPPORTS" = "xyes" -a "x$CXX_COMP_SUPPORTS" = "xyes"; then supports=yes; fi
  
-@@ -41755,12 +41755,12 @@ $as_echo "$supports" >&6; }
+@@ -41750,12 +41750,12 @@ $as_echo "$supports" >&6; }
    NO_LIFETIME_DSE_CFLAG="-fno-lifetime-dse"
  
  
@@ -141,7 +142,7 @@ index f285a74..31d41b1 100644
    ac_ext=c
  ac_cpp='$CPP $CPPFLAGS'
  ac_compile='$CC -c $CFLAGS $CPPFLAGS conftest.$ac_ext >&5'
-@@ -41794,12 +41794,12 @@ $as_echo "$supports" >&6; }
+@@ -41789,12 +41789,12 @@ $as_echo "$supports" >&6; }
    fi
  
  
@@ -157,7 +158,7 @@ index f285a74..31d41b1 100644
    ac_ext=cpp
  ac_cpp='$CXXCPP $CPPFLAGS'
  ac_compile='$CXX -c $CXXFLAGS $CPPFLAGS conftest.$ac_ext >&5'
-@@ -41833,8 +41833,8 @@ $as_echo "$supports" >&6; }
+@@ -41828,8 +41828,8 @@ $as_echo "$supports" >&6; }
    fi
  
  
@@ -168,7 +169,7 @@ index f285a74..31d41b1 100644
    supports=no
    if test "x$C_COMP_SUPPORTS" = "xyes" -a "x$CXX_COMP_SUPPORTS" = "xyes"; then supports=yes; fi
  
-@@ -41867,12 +41867,12 @@ $as_echo "$supports" >&6; }
+@@ -41862,12 +41862,12 @@ $as_echo "$supports" >&6; }
      #          -mno-fused-madd -fno-strict-aliasing for GCC < 4.6
      COMPILER_FP_CONTRACT_OFF_FLAG="-ffp-contract=off"
  
@@ -184,7 +185,7 @@ index f285a74..31d41b1 100644
    ac_ext=cpp
  ac_cpp='$CXXCPP $CPPFLAGS'
  ac_compile='$CXX -c $CXXFLAGS $CPPFLAGS conftest.$ac_ext >&5'
-@@ -41911,12 +41911,12 @@ $as_echo "$supports" >&6; }
+@@ -41906,12 +41906,12 @@ $as_echo "$supports" >&6; }
           test "$OPENJDK_TARGET_CPU_ARCH" = "ppc"; then
          M_NO_FUSED_ADD_FLAG="-mno-fused-madd"
  
@@ -200,7 +201,7 @@ index f285a74..31d41b1 100644
    ac_ext=cpp
  ac_cpp='$CXXCPP $CPPFLAGS'
  ac_compile='$CXX -c $CXXFLAGS $CPPFLAGS conftest.$ac_ext >&5'
-@@ -41951,12 +41951,12 @@ $as_echo "$supports" >&6; }
+@@ -41946,12 +41946,12 @@ $as_echo "$supports" >&6; }
  
          NO_STRICT_ALIASING_FLAG="-fno-strict-aliasing"
  
@@ -216,6 +217,3 @@ index f285a74..31d41b1 100644
    ac_ext=cpp
  ac_cpp='$CXXCPP $CPPFLAGS'
  ac_compile='$CXX -c $CXXFLAGS $CPPFLAGS conftest.$ac_ext >&5'
--- 
-2.26.2
-

--- a/recipes-core/openjdk/patches-openjdk-8/1002-hotspot-use-correct-include-for-poll.patch
+++ b/recipes-core/openjdk/patches-openjdk-8/1002-hotspot-use-correct-include-for-poll.patch
@@ -1,7 +1,7 @@
-From e40d948b71ff33d74c6e1595a798f359fb673d8f Mon Sep 17 00:00:00 2001
+From 9f2a5acce1da9908a7e94388880c831e1635e51f Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Andr=C3=A9=20Draszik?= <andre.draszik@jci.com>
 Date: Tue, 27 Feb 2018 09:28:06 +0000
-Subject: [PATCH 1002/1013] hotspot: use correct include for poll
+Subject: [PATCH] hotspot: use correct include for poll
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
 Content-Transfer-Encoding: 8bit
@@ -23,15 +23,16 @@ Upstream-Status: Pending
 
 Signed-off-by: André Draszik <andre.draszik@jci.com>
 Signed-off-by: Richard Leitner <richard.leitner@skidata.com>
+
 ---
- src/os/aix/vm/os_aix.inline.hpp         | 2 +-
- src/os/bsd/vm/os_bsd.inline.hpp         | 2 +-
- src/os/linux/vm/os_linux.inline.hpp     | 2 +-
- src/os/solaris/vm/os_solaris.inline.hpp | 2 +-
+ hotspot/src/os/aix/vm/os_aix.inline.hpp         | 2 +-
+ hotspot/src/os/bsd/vm/os_bsd.inline.hpp         | 2 +-
+ hotspot/src/os/linux/vm/os_linux.inline.hpp     | 2 +-
+ hotspot/src/os/solaris/vm/os_solaris.inline.hpp | 2 +-
  4 files changed, 4 insertions(+), 4 deletions(-)
 
 diff --git a/hotspot/src/os/aix/vm/os_aix.inline.hpp b/hotspot/src/os/aix/vm/os_aix.inline.hpp
-index 421ea342e..9a1e1e096 100644
+index 421ea342..9a1e1e09 100644
 --- a/hotspot/src/os/aix/vm/os_aix.inline.hpp
 +++ b/hotspot/src/os/aix/vm/os_aix.inline.hpp
 @@ -34,7 +34,7 @@
@@ -44,7 +45,7 @@ index 421ea342e..9a1e1e096 100644
  #include <netdb.h>
  
 diff --git a/hotspot/src/os/bsd/vm/os_bsd.inline.hpp b/hotspot/src/os/bsd/vm/os_bsd.inline.hpp
-index c35abf486..8ff584aee 100644
+index c35abf48..8ff584ae 100644
 --- a/hotspot/src/os/bsd/vm/os_bsd.inline.hpp
 +++ b/hotspot/src/os/bsd/vm/os_bsd.inline.hpp
 @@ -33,7 +33,7 @@
@@ -57,7 +58,7 @@ index c35abf486..8ff584aee 100644
  
  inline void* os::thread_local_storage_at(int index) {
 diff --git a/hotspot/src/os/linux/vm/os_linux.inline.hpp b/hotspot/src/os/linux/vm/os_linux.inline.hpp
-index a23bd5631..9d56de0ef 100644
+index a23bd563..9d56de0e 100644
 --- a/hotspot/src/os/linux/vm/os_linux.inline.hpp
 +++ b/hotspot/src/os/linux/vm/os_linux.inline.hpp
 @@ -33,7 +33,7 @@
@@ -70,7 +71,7 @@ index a23bd5631..9d56de0ef 100644
  
  inline void* os::thread_local_storage_at(int index) {
 diff --git a/hotspot/src/os/solaris/vm/os_solaris.inline.hpp b/hotspot/src/os/solaris/vm/os_solaris.inline.hpp
-index 8e095ab69..ce37e9a12 100644
+index 8e095ab6..ce37e9a1 100644
 --- a/hotspot/src/os/solaris/vm/os_solaris.inline.hpp
 +++ b/hotspot/src/os/solaris/vm/os_solaris.inline.hpp
 @@ -33,7 +33,7 @@
@@ -82,6 +83,3 @@ index 8e095ab69..ce37e9a12 100644
  #include <sys/filio.h>
  #include <unistd.h>
  #include <netdb.h>
--- 
-2.26.2
-

--- a/recipes-core/openjdk/patches-openjdk-8/1003-hotspot-don-t-rely-on-old-SysV-SIGCLD.patch
+++ b/recipes-core/openjdk/patches-openjdk-8/1003-hotspot-don-t-rely-on-old-SysV-SIGCLD.patch
@@ -1,7 +1,7 @@
-From 1a4d6458d94bc275a740cab895f8ada303916cd6 Mon Sep 17 00:00:00 2001
+From 7e40a364af1427b5f5238cd8d49e947db1c1557d Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Andr=C3=A9=20Draszik?= <andre.draszik@jci.com>
 Date: Tue, 27 Feb 2018 15:00:55 +0000
-Subject: [PATCH 1003/1013] hotspot: don't rely on old SysV SIGCLD
+Subject: [PATCH] hotspot: don't rely on old SysV SIGCLD
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
 Content-Transfer-Encoding: 8bit
@@ -20,12 +20,13 @@ Upstream-Status: Pending
 
 Signed-off-by: André Draszik <andre.draszik@jci.com>
 Signed-off-by: Richard Leitner <richard.leitner@skidata.com>
+
 ---
- src/os/linux/vm/jvm_linux.cpp | 2 ++
+ hotspot/src/os/linux/vm/jvm_linux.cpp | 2 ++
  1 file changed, 2 insertions(+)
 
 diff --git a/hotspot/src/os/linux/vm/jvm_linux.cpp b/hotspot/src/os/linux/vm/jvm_linux.cpp
-index ba84788a1..c22281f7c 100644
+index ba84788a..c22281f7 100644
 --- a/hotspot/src/os/linux/vm/jvm_linux.cpp
 +++ b/hotspot/src/os/linux/vm/jvm_linux.cpp
 @@ -154,7 +154,9 @@ struct siglabel siglabels[] = {
@@ -38,6 +39,3 @@ index ba84788a1..c22281f7c 100644
    "CHLD",       SIGCHLD,        /* Child status has changed (POSIX).  */
    "CONT",       SIGCONT,        /* Continue (POSIX).  */
    "STOP",       SIGSTOP,        /* Stop, unblockable (POSIX).  */
--- 
-2.26.2
-

--- a/recipes-core/openjdk/patches-openjdk-8/1004-hotspot-fix-Wreturn-type-issues-introduced-by-806165.patch
+++ b/recipes-core/openjdk/patches-openjdk-8/1004-hotspot-fix-Wreturn-type-issues-introduced-by-806165.patch
@@ -1,8 +1,7 @@
-From 794a7bf743e23ff74c4900801ddc56c253542b44 Mon Sep 17 00:00:00 2001
+From 7cca9e147d9f4b98ffbc6b10e817d2e8dbd686fb Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Andr=C3=A9=20Draszik?= <andre.draszik@jci.com>
 Date: Mon, 13 Aug 2018 16:40:34 +0100
-Subject: [PATCH 1004/1013] hotspot: fix -Wreturn-type issues introduced by
- 8061651
+Subject: [PATCH] hotspot: fix -Wreturn-type issues introduced by 8061651
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
 Content-Transfer-Encoding: 8bit
@@ -19,12 +18,13 @@ Upstream-Status: Backport
 
 Signed-off-by: André Draszik <andre.draszik@jci.com>
 Signed-off-by: Richard Leitner <richard.leitner@skidata.com>
+
 ---
- src/share/vm/prims/jvm.cpp | 6 +++---
+ hotspot/src/share/vm/prims/jvm.cpp | 6 +++---
  1 file changed, 3 insertions(+), 3 deletions(-)
 
 diff --git a/hotspot/src/share/vm/prims/jvm.cpp b/hotspot/src/share/vm/prims/jvm.cpp
-index c32c98ade..6f2221c41 100644
+index c32c98ad..6f2221c4 100644
 --- a/hotspot/src/share/vm/prims/jvm.cpp
 +++ b/hotspot/src/share/vm/prims/jvm.cpp
 @@ -929,7 +929,7 @@ JVM_END
@@ -54,6 +54,3 @@ index c32c98ade..6f2221c41 100644
  #else
    return NULL;
  #endif
--- 
-2.26.2
-

--- a/recipes-core/openjdk/patches-openjdk-8/1005-hotspot-Zero-build-requires-disabled-warnings.patch
+++ b/recipes-core/openjdk/patches-openjdk-8/1005-hotspot-Zero-build-requires-disabled-warnings.patch
@@ -1,7 +1,7 @@
-From f8a3f19fa4fabaf57b0c2c77e966d9896399b3f8 Mon Sep 17 00:00:00 2001
+From 9ae232a21a7c2cec88cdb4ff7e6cf7092f1578ab Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Andr=C3=A9=20Draszik?= <andre.draszik@jci.com>
 Date: Mon, 13 Aug 2018 16:45:24 +0100
-Subject: [PATCH 1005/1013] hotspot: Zero build requires disabled warnings
+Subject: [PATCH] hotspot: Zero build requires disabled warnings
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
 Content-Transfer-Encoding: 8bit
@@ -19,15 +19,16 @@ Upstream-Status: Backport
 
 Signed-off-by: André Draszik <andre.draszik@jci.com>
 Signed-off-by: Richard Leitner <richard.leitner@skidata.com>
+
 ---
- src/cpu/zero/vm/cppInterpreter_zero.cpp        |  2 +-
- src/cpu/zero/vm/interpreterRT_zero.cpp         |  4 ++--
- src/os_cpu/linux_zero/vm/os_linux_zero.cpp     | 14 ++++++++++++--
- src/os_cpu/linux_zero/vm/thread_linux_zero.hpp |  3 ++-
+ hotspot/src/cpu/zero/vm/cppInterpreter_zero.cpp    |  2 +-
+ hotspot/src/cpu/zero/vm/interpreterRT_zero.cpp     |  4 ++--
+ hotspot/src/os_cpu/linux_zero/vm/os_linux_zero.cpp | 14 ++++++++++++--
+ .../src/os_cpu/linux_zero/vm/thread_linux_zero.hpp |  3 ++-
  4 files changed, 17 insertions(+), 6 deletions(-)
 
 diff --git a/hotspot/src/cpu/zero/vm/cppInterpreter_zero.cpp b/hotspot/src/cpu/zero/vm/cppInterpreter_zero.cpp
-index 525031eb9..d47422b8c 100644
+index 525031eb..d47422b8 100644
 --- a/hotspot/src/cpu/zero/vm/cppInterpreter_zero.cpp
 +++ b/hotspot/src/cpu/zero/vm/cppInterpreter_zero.cpp
 @@ -100,7 +100,7 @@ intptr_t narrow(BasicType type, intptr_t result) {
@@ -40,7 +41,7 @@ index 525031eb9..d47422b8c 100644
  }
  
 diff --git a/hotspot/src/cpu/zero/vm/interpreterRT_zero.cpp b/hotspot/src/cpu/zero/vm/interpreterRT_zero.cpp
-index e23e3eaa9..061ed8ce8 100644
+index e23e3eaa..061ed8ce 100644
 --- a/hotspot/src/cpu/zero/vm/interpreterRT_zero.cpp
 +++ b/hotspot/src/cpu/zero/vm/interpreterRT_zero.cpp
 @@ -1,5 +1,5 @@
@@ -60,7 +61,7 @@ index e23e3eaa9..061ed8ce8 100644
    case T_VOID:
      ftype = &ffi_type_void;
 diff --git a/hotspot/src/os_cpu/linux_zero/vm/os_linux_zero.cpp b/hotspot/src/os_cpu/linux_zero/vm/os_linux_zero.cpp
-index d22ea1141..cbee43baa 100644
+index d22ea114..cbee43ba 100644
 --- a/hotspot/src/os_cpu/linux_zero/vm/os_linux_zero.cpp
 +++ b/hotspot/src/os_cpu/linux_zero/vm/os_linux_zero.cpp
 @@ -61,6 +61,7 @@ address os::current_stack_pointer() {
@@ -119,7 +120,7 @@ index d22ea1141..cbee43baa 100644
  
  void os::Linux::set_fpu_control_word(int fpu) {
 diff --git a/hotspot/src/os_cpu/linux_zero/vm/thread_linux_zero.hpp b/hotspot/src/os_cpu/linux_zero/vm/thread_linux_zero.hpp
-index 94bc83a30..b3ba526f2 100644
+index 94bc83a3..b3ba526f 100644
 --- a/hotspot/src/os_cpu/linux_zero/vm/thread_linux_zero.hpp
 +++ b/hotspot/src/os_cpu/linux_zero/vm/thread_linux_zero.hpp
 @@ -1,5 +1,5 @@
@@ -137,6 +138,3 @@ index 94bc83a30..b3ba526f2 100644
    }
  
    bool pd_get_top_frame_for_profiling(frame* fr_addr,
--- 
-2.26.2
-

--- a/recipes-core/openjdk/patches-openjdk-8/1006-hotspot-Missing-return-statement-in-__sync_val_compa.patch
+++ b/recipes-core/openjdk/patches-openjdk-8/1006-hotspot-Missing-return-statement-in-__sync_val_compa.patch
@@ -1,7 +1,7 @@
-From 5e21de887d87243b6be03781afb4015c4673851c Mon Sep 17 00:00:00 2001
+From 1f618dcda554d85d1c1dcd1bfd84d9554cb2f3b8 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Andr=C3=A9=20Draszik?= <andre.draszik@jci.com>
 Date: Mon, 13 Aug 2018 16:46:33 +0100
-Subject: [PATCH 1006/1013] hotspot: Missing return statement in
+Subject: [PATCH] hotspot: Missing return statement in
  __sync_val_compare_and_swap_8
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
@@ -21,13 +21,14 @@ Upstream-Status: Backport
 
 Signed-off-by: André Draszik <andre.draszik@jci.com>
 Signed-off-by: Richard Leitner <richard.leitner@skidata.com>
+
 ---
- src/os_cpu/bsd_zero/vm/os_bsd_zero.cpp     | 1 +
- src/os_cpu/linux_zero/vm/os_linux_zero.cpp | 1 +
+ hotspot/src/os_cpu/bsd_zero/vm/os_bsd_zero.cpp     | 1 +
+ hotspot/src/os_cpu/linux_zero/vm/os_linux_zero.cpp | 1 +
  2 files changed, 2 insertions(+)
 
 diff --git a/hotspot/src/os_cpu/bsd_zero/vm/os_bsd_zero.cpp b/hotspot/src/os_cpu/bsd_zero/vm/os_bsd_zero.cpp
-index c857b5526..4aaf78b1d 100644
+index c857b552..4aaf78b1 100644
 --- a/hotspot/src/os_cpu/bsd_zero/vm/os_bsd_zero.cpp
 +++ b/hotspot/src/os_cpu/bsd_zero/vm/os_bsd_zero.cpp
 @@ -457,6 +457,7 @@ extern "C" {
@@ -39,7 +40,7 @@ index c857b5526..4aaf78b1d 100644
  };
  #endif // !_LP64
 diff --git a/hotspot/src/os_cpu/linux_zero/vm/os_linux_zero.cpp b/hotspot/src/os_cpu/linux_zero/vm/os_linux_zero.cpp
-index cbee43baa..136d4d3de 100644
+index cbee43ba..136d4d3d 100644
 --- a/hotspot/src/os_cpu/linux_zero/vm/os_linux_zero.cpp
 +++ b/hotspot/src/os_cpu/linux_zero/vm/os_linux_zero.cpp
 @@ -498,6 +498,7 @@ extern "C" {
@@ -50,6 +51,3 @@ index cbee43baa..136d4d3de 100644
    }
  };
  #endif // !_LP64
--- 
-2.26.2
-

--- a/recipes-core/openjdk/patches-openjdk-8/1007-hotspot-Turn-on-the-Wreturn-type-warning.patch
+++ b/recipes-core/openjdk/patches-openjdk-8/1007-hotspot-Turn-on-the-Wreturn-type-warning.patch
@@ -1,7 +1,11 @@
-From 024e0d522f205ca8659fce60ca4be68b9e3e08db Mon Sep 17 00:00:00 2001
+From 6758bf27e31110dc5d4c7237476c823ff05454a2 Mon Sep 17 00:00:00 2001
 From: Richard Leitner <richard.leitner@skidata.com>
 Date: Thu, 22 Oct 2020 09:41:07 +0200
-Subject: [PATCH 1007/1013] hotspot: Turn on the -Wreturn-type warning
+Subject: [PATCH] hotspot: Turn on the -Wreturn-type warning
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
 Content-Transfer-Encoding: 8bit
@@ -19,27 +23,28 @@ Upstream-Status: Backport
 
 Signed-off-by: André Draszik <andre.draszik@jci.com>
 Signed-off-by: Richard Leitner <richard.leitner@skidata.com>
+
 ---
- make/linux/makefiles/gcc.make               | 2 +-
- src/cpu/x86/vm/x86_32.ad                    | 1 +
- src/os_cpu/linux_x86/vm/os_linux_x86.cpp    | 1 +
- src/share/vm/classfile/defaultMethods.cpp   | 4 ++--
- src/share/vm/classfile/symbolTable.cpp      | 4 ++--
- src/share/vm/classfile/systemDictionary.cpp | 6 +++---
- src/share/vm/memory/heapInspection.hpp      | 2 +-
- src/share/vm/memory/metaspaceShared.hpp     | 2 +-
- src/share/vm/oops/constantPool.hpp          | 2 +-
- src/share/vm/prims/jvm.cpp                  | 2 +-
- src/share/vm/runtime/reflection.cpp         | 2 +-
- src/share/vm/runtime/sharedRuntime.cpp      | 2 +-
- src/share/vm/services/memTracker.hpp        | 2 +-
+ hotspot/make/linux/makefiles/gcc.make               | 2 +-
+ hotspot/src/cpu/x86/vm/x86_32.ad                    | 1 +
+ hotspot/src/os_cpu/linux_x86/vm/os_linux_x86.cpp    | 1 +
+ hotspot/src/share/vm/classfile/defaultMethods.cpp   | 4 ++--
+ hotspot/src/share/vm/classfile/symbolTable.cpp      | 4 ++--
+ hotspot/src/share/vm/classfile/systemDictionary.cpp | 6 +++---
+ hotspot/src/share/vm/memory/heapInspection.hpp      | 2 +-
+ hotspot/src/share/vm/memory/metaspaceShared.hpp     | 2 +-
+ hotspot/src/share/vm/oops/constantPool.hpp          | 2 +-
+ hotspot/src/share/vm/prims/jvm.cpp                  | 2 +-
+ hotspot/src/share/vm/runtime/reflection.cpp         | 2 +-
+ hotspot/src/share/vm/runtime/sharedRuntime.cpp      | 2 +-
+ hotspot/src/share/vm/services/memTracker.hpp        | 2 +-
  13 files changed, 17 insertions(+), 15 deletions(-)
 
 diff --git a/hotspot/make/linux/makefiles/gcc.make b/hotspot/make/linux/makefiles/gcc.make
-index ac44b6837..7a5162a06 100644
+index 36b3c8ba..cd9511e5 100644
 --- a/hotspot/make/linux/makefiles/gcc.make
 +++ b/hotspot/make/linux/makefiles/gcc.make
-@@ -212,7 +212,7 @@ ifeq ($(USE_CLANG), true)
+@@ -211,7 +211,7 @@ ifeq ($(USE_CLANG), true)
    WARNINGS_ARE_ERRORS += -Wno-return-type -Wno-empty-body
  endif
  
@@ -49,7 +54,7 @@ index ac44b6837..7a5162a06 100644
  ifeq ($(USE_CLANG),)
    # Since GCC 4.3, -Wconversion has changed its meanings to warn these implicit
 diff --git a/hotspot/src/cpu/x86/vm/x86_32.ad b/hotspot/src/cpu/x86/vm/x86_32.ad
-index f42d1a288..c8f4ee161 100644
+index f42d1a28..c8f4ee16 100644
 --- a/hotspot/src/cpu/x86/vm/x86_32.ad
 +++ b/hotspot/src/cpu/x86/vm/x86_32.ad
 @@ -1250,6 +1250,7 @@ uint MachSpillCopyNode::implementation( CodeBuffer *cbuf, PhaseRegAlloc *ra_, bo
@@ -61,7 +66,7 @@ index f42d1a288..c8f4ee161 100644
  
  #ifndef PRODUCT
 diff --git a/hotspot/src/os_cpu/linux_x86/vm/os_linux_x86.cpp b/hotspot/src/os_cpu/linux_x86/vm/os_linux_x86.cpp
-index c35d8677f..65c3165ca 100644
+index c35d8677..65c3165c 100644
 --- a/hotspot/src/os_cpu/linux_x86/vm/os_linux_x86.cpp
 +++ b/hotspot/src/os_cpu/linux_x86/vm/os_linux_x86.cpp
 @@ -541,6 +541,7 @@ JVM_handle_linux_signal(int sig,
@@ -73,7 +78,7 @@ index c35d8677f..65c3165ca 100644
  
  void os::Linux::init_thread_fpu_state(void) {
 diff --git a/hotspot/src/share/vm/classfile/defaultMethods.cpp b/hotspot/src/share/vm/classfile/defaultMethods.cpp
-index 4b4b4e250..196622aed 100644
+index 4b4b4e25..196622ae 100644
 --- a/hotspot/src/share/vm/classfile/defaultMethods.cpp
 +++ b/hotspot/src/share/vm/classfile/defaultMethods.cpp
 @@ -506,7 +506,7 @@ Symbol* MethodFamily::generate_method_message(Symbol *klass_name, Method* method
@@ -95,7 +100,7 @@ index 4b4b4e250..196622aed 100644
  
  
 diff --git a/hotspot/src/share/vm/classfile/symbolTable.cpp b/hotspot/src/share/vm/classfile/symbolTable.cpp
-index ec97077b7..2621a7d62 100644
+index 83369cbc..8dd4e6b2 100644
 --- a/hotspot/src/share/vm/classfile/symbolTable.cpp
 +++ b/hotspot/src/share/vm/classfile/symbolTable.cpp
 @@ -249,7 +249,7 @@ Symbol* SymbolTable::lookup(const char* name, int len, TRAPS) {
@@ -117,7 +122,7 @@ index ec97077b7..2621a7d62 100644
  
  Symbol* SymbolTable::lookup_only(const char* name, int len,
 diff --git a/hotspot/src/share/vm/classfile/systemDictionary.cpp b/hotspot/src/share/vm/classfile/systemDictionary.cpp
-index 5911d94f5..df4d56f6f 100644
+index 4541e815..98412e1e 100644
 --- a/hotspot/src/share/vm/classfile/systemDictionary.cpp
 +++ b/hotspot/src/share/vm/classfile/systemDictionary.cpp
 @@ -236,15 +236,15 @@ Klass* SystemDictionary::resolve_or_null(Symbol* class_name, Handle class_loader
@@ -140,7 +145,7 @@ index 5911d94f5..df4d56f6f 100644
  }
  
 diff --git a/hotspot/src/share/vm/memory/heapInspection.hpp b/hotspot/src/share/vm/memory/heapInspection.hpp
-index 09ee6602e..c5fec15c3 100644
+index 09ee6602..c5fec15c 100644
 --- a/hotspot/src/share/vm/memory/heapInspection.hpp
 +++ b/hotspot/src/share/vm/memory/heapInspection.hpp
 @@ -367,7 +367,7 @@ class HeapInspection : public StackObj {
@@ -153,7 +158,7 @@ index 09ee6602e..c5fec15c3 100644
   private:
    void iterate_over_heap(KlassInfoTable* cit, BoolObjectClosure* filter = NULL);
 diff --git a/hotspot/src/share/vm/memory/metaspaceShared.hpp b/hotspot/src/share/vm/memory/metaspaceShared.hpp
-index 2f3abae6a..d58ebecb2 100644
+index 2f3abae6..d58ebecb 100644
 --- a/hotspot/src/share/vm/memory/metaspaceShared.hpp
 +++ b/hotspot/src/share/vm/memory/metaspaceShared.hpp
 @@ -93,7 +93,7 @@ class MetaspaceShared : AllStatic {
@@ -166,10 +171,10 @@ index 2f3abae6a..d58ebecb2 100644
    static ReservedSpace* shared_rs() {
      CDS_ONLY(return _shared_rs);
 diff --git a/hotspot/src/share/vm/oops/constantPool.hpp b/hotspot/src/share/vm/oops/constantPool.hpp
-index 124c970e2..dae574c09 100644
+index 68435471..fad4a92c 100644
 --- a/hotspot/src/share/vm/oops/constantPool.hpp
 +++ b/hotspot/src/share/vm/oops/constantPool.hpp
-@@ -353,7 +353,7 @@ class ConstantPool : public Metadata {
+@@ -350,7 +350,7 @@ class ConstantPool : public Metadata {
  
    Klass* klass_at(int which, TRAPS) {
      constantPoolHandle h_this(THREAD, this);
@@ -177,9 +182,9 @@ index 124c970e2..dae574c09 100644
 +    return klass_at_impl(h_this, which, THREAD);
    }
  
-   Symbol* klass_name_at(int which);  // Returns the name, w/o resolving.
+   Symbol* klass_name_at(int which) const;  // Returns the name, w/o resolving.
 diff --git a/hotspot/src/share/vm/prims/jvm.cpp b/hotspot/src/share/vm/prims/jvm.cpp
-index 6f2221c41..daa69f89a 100644
+index 6f2221c4..daa69f89 100644
 --- a/hotspot/src/share/vm/prims/jvm.cpp
 +++ b/hotspot/src/share/vm/prims/jvm.cpp
 @@ -4368,7 +4368,7 @@ JVM_ENTRY(jlong,JVM_DTraceActivate(
@@ -192,7 +197,7 @@ index 6f2221c41..daa69f89a 100644
  
  JVM_ENTRY(jboolean,JVM_DTraceIsProbeEnabled(JNIEnv* env, jmethodID method))
 diff --git a/hotspot/src/share/vm/runtime/reflection.cpp b/hotspot/src/share/vm/runtime/reflection.cpp
-index d9fddbe47..a5f737935 100644
+index 4b39d8cc..9cd7b0dc 100644
 --- a/hotspot/src/share/vm/runtime/reflection.cpp
 +++ b/hotspot/src/share/vm/runtime/reflection.cpp
 @@ -1093,7 +1093,7 @@ oop Reflection::invoke(instanceKlassHandle klass, methodHandle reflected_method,
@@ -205,10 +210,10 @@ index d9fddbe47..a5f737935 100644
  }
  
 diff --git a/hotspot/src/share/vm/runtime/sharedRuntime.cpp b/hotspot/src/share/vm/runtime/sharedRuntime.cpp
-index 013aa7a23..df4cde963 100644
+index d5bea29c..50578ad6 100644
 --- a/hotspot/src/share/vm/runtime/sharedRuntime.cpp
 +++ b/hotspot/src/share/vm/runtime/sharedRuntime.cpp
-@@ -1045,7 +1045,7 @@ Handle SharedRuntime::find_callee_info(JavaThread* thread, Bytecodes::Code& bc,
+@@ -1041,7 +1041,7 @@ Handle SharedRuntime::find_callee_info(JavaThread* thread, Bytecodes::Code& bc,
    // last java frame on stack (which includes native call frames)
    vframeStream vfst(thread, true);  // Do not skip and javaCalls
  
@@ -218,7 +223,7 @@ index 013aa7a23..df4cde963 100644
  
  
 diff --git a/hotspot/src/share/vm/services/memTracker.hpp b/hotspot/src/share/vm/services/memTracker.hpp
-index 8ea859ddb..535147f8c 100644
+index 8ea859dd..535147f8 100644
 --- a/hotspot/src/share/vm/services/memTracker.hpp
 +++ b/hotspot/src/share/vm/services/memTracker.hpp
 @@ -64,7 +64,7 @@ class MemTracker : AllStatic {
@@ -230,6 +235,3 @@ index 8ea859ddb..535147f8c 100644
    static inline void record_virtual_memory_type(void* addr, MEMFLAGS flag) { }
    static inline void record_thread_stack(void* addr, size_t size) { }
    static inline void release_thread_stack(void* addr, size_t size) { }
--- 
-2.26.2
-

--- a/recipes-core/openjdk/patches-openjdk-8/1008-hotspot-handle-format-error-for-GCC-7.patch
+++ b/recipes-core/openjdk/patches-openjdk-8/1008-hotspot-handle-format-error-for-GCC-7.patch
@@ -1,18 +1,19 @@
-From dc6db949f4140b2dd7d3dfe040984bdfd88f2ba0 Mon Sep 17 00:00:00 2001
+From bb394ba055197ef7c7e27b436dd92f5a86305019 Mon Sep 17 00:00:00 2001
 From: Andreas Obergschwandtner <andreas.obergschwandtner@skidata.com>
 Date: Fri, 21 Sep 2018 10:44:06 +0200
-Subject: [PATCH 1008/1013] hotspot: handle format error for GCC >= 7
+Subject: [PATCH] hotspot: handle format error for GCC >= 7
 
 Upstream-Status: Pending
 
 Signed-off-by: Andreas Obergschwandtner <andreas.obergschwandtner@skidata.com>
 Signed-off-by: Richard Leitner <richard.leitner@skidata.com>
+
 ---
- src/share/vm/adlc/output_c.cpp | 6 ++++--
+ hotspot/src/share/vm/adlc/output_c.cpp | 6 ++++--
  1 file changed, 4 insertions(+), 2 deletions(-)
 
 diff --git a/hotspot/src/share/vm/adlc/output_c.cpp b/hotspot/src/share/vm/adlc/output_c.cpp
-index 199169046..889b785c1 100644
+index 19916904..889b785c 100644
 --- a/hotspot/src/share/vm/adlc/output_c.cpp
 +++ b/hotspot/src/share/vm/adlc/output_c.cpp
 @@ -419,9 +419,11 @@ static int pipeline_res_mask_initializer(
@@ -29,6 +30,3 @@ index 199169046..889b785c1 100644
  
    static const char* pipeline_use_cycle_mask = "Pipeline_Use_Cycle_Mask";
    static const char* pipeline_use_element    = "Pipeline_Use_Element";
--- 
-2.26.2
-

--- a/recipes-core/openjdk/patches-openjdk-8/1012-hotspot-enable-Wno-error.patch
+++ b/recipes-core/openjdk/patches-openjdk-8/1012-hotspot-enable-Wno-error.patch
@@ -1,7 +1,7 @@
-From 37b5885e35a7974bbd8895ae9a7e9ec7ebf9dc68 Mon Sep 17 00:00:00 2001
+From 2303926f157f8c90cef167c43bd530793c19e480 Mon Sep 17 00:00:00 2001
 From: Richard Leitner <richard.leitner@skidata.com>
 Date: Thu, 20 Aug 2020 09:39:23 +0200
-Subject: [PATCH 1012/1013] hotspot: enable -Wno-error
+Subject: [PATCH] hotspot: enable -Wno-error
 
 As we don't want to deal with compiler warnings in OpenEmbedded disable
 them for now.
@@ -9,15 +9,16 @@ them for now.
 Upstream-Status: Pending
 
 Signed-off-by: Richard Leitner <richard.leitner@skidata.com>
+
 ---
- make/linux/makefiles/gcc.make | 4 ++--
+ hotspot/make/linux/makefiles/gcc.make | 4 ++--
  1 file changed, 2 insertions(+), 2 deletions(-)
 
 diff --git a/hotspot/make/linux/makefiles/gcc.make b/hotspot/make/linux/makefiles/gcc.make
-index 7a5162a06..67607fb26 100644
+index cd9511e5..94412c8f 100644
 --- a/hotspot/make/linux/makefiles/gcc.make
 +++ b/hotspot/make/linux/makefiles/gcc.make
-@@ -201,8 +201,8 @@ else
+@@ -200,8 +200,8 @@ else
    CFLAGS += -pipe
  endif
  
@@ -28,6 +29,3 @@ index 7a5162a06..67607fb26 100644
  
  ifeq ($(USE_CLANG), true)
    # However we need to clean the code up before we can unrestrictedly enable this option with Clang
--- 
-2.26.2
-

--- a/recipes-core/openjdk/patches-openjdk-8/2001-jdk-comparison-between-pointer-and-integer.patch
+++ b/recipes-core/openjdk/patches-openjdk-8/2001-jdk-comparison-between-pointer-and-integer.patch
@@ -1,7 +1,7 @@
-From b4e7774c35cf29aaca2bd04d115afc3ea3c77d7a Mon Sep 17 00:00:00 2001
+From dcf3e46758fa5e77ce6fb4b3f51867bb5186f8f0 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Andr=C3=A9=20Draszik?= <andre.draszik@jci.com>
 Date: Fri, 2 Mar 2018 11:13:08 +0000
-Subject: [PATCH 2001/2009] jdk: comparison between pointer and integer
+Subject: [PATCH] jdk: comparison between pointer and integer
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
 Content-Transfer-Encoding: 8bit
@@ -21,14 +21,15 @@ Upstream-Status: Backport [http://hg.openjdk.java.net/jdk9/jdk9/jdk/rev/90c64359
 
 Signed-off-by: André Draszik <andre.draszik@jci.com>
 Signed-off-by: Richard Leitner <richard.leitner@skidata.com>
+
 ---
- src/share/native/java/net/net_util.c           | 15 +++++++--------
- src/share/native/java/net/net_util.h           |  8 ++++----
- src/solaris/native/java/net/Inet6AddressImpl.c |  4 ++--
+ jdk/src/share/native/java/net/net_util.c          | 15 +++++++--------
+ jdk/src/share/native/java/net/net_util.h          |  8 ++++----
+ .../solaris/native/java/net/Inet6AddressImpl.c    |  4 ++--
  3 files changed, 13 insertions(+), 14 deletions(-)
 
 diff --git a/jdk/src/share/native/java/net/net_util.c b/jdk/src/share/native/java/net/net_util.c
-index b1b8223a63..2eee6261ac 100644
+index b1b8223a..2eee6261 100644
 --- a/jdk/src/share/native/java/net/net_util.c
 +++ b/jdk/src/share/native/java/net/net_util.c
 @@ -108,7 +108,7 @@ jobject getInet6Address_scopeifname(JNIEnv *env, jobject iaObj) {
@@ -99,7 +100,7 @@ index b1b8223a63..2eee6261ac 100644
              int scope;
  
 diff --git a/jdk/src/share/native/java/net/net_util.h b/jdk/src/share/native/java/net/net_util.h
-index c8a5e68c49..176ca586ee 100644
+index c8a5e68c..176ca586 100644
 --- a/jdk/src/share/native/java/net/net_util.h
 +++ b/jdk/src/share/native/java/net/net_util.h
 @@ -64,12 +64,12 @@ JNIEXPORT void JNICALL initInetAddressIDs(JNIEnv *env);
@@ -120,7 +121,7 @@ index c8a5e68c49..176ca586ee 100644
  extern void setInetAddress_addr(JNIEnv *env, jobject iaObj, int address);
  extern void setInetAddress_family(JNIEnv *env, jobject iaObj, int family);
 diff --git a/jdk/src/solaris/native/java/net/Inet6AddressImpl.c b/jdk/src/solaris/native/java/net/Inet6AddressImpl.c
-index 0a51a365fd..dcc348cf1f 100644
+index 0a51a365..dcc348cf 100644
 --- a/jdk/src/solaris/native/java/net/Inet6AddressImpl.c
 +++ b/jdk/src/solaris/native/java/net/Inet6AddressImpl.c
 @@ -392,7 +392,7 @@ Java_java_net_Inet6AddressImpl_lookupAllHostAddr(JNIEnv *env, jobject this,
@@ -141,6 +142,3 @@ index 0a51a365fd..dcc348cf1f 100644
                      ret = NULL;
                      goto cleanupAndReturn;
                  }
--- 
-2.26.2
-

--- a/recipes-core/openjdk/patches-openjdk-8/2002-jdk-Allow-using-a-system-installed-libjpeg.patch
+++ b/recipes-core/openjdk/patches-openjdk-8/2002-jdk-Allow-using-a-system-installed-libjpeg.patch
@@ -1,7 +1,7 @@
-From 1d7ea474a12a12e0e28e1a24f686a7478fe42b8d Mon Sep 17 00:00:00 2001
+From a1a63e85513aa3501588b02940e4f0e93e992e89 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Andr=C3=A9=20Draszik?= <andre.draszik@jci.com>
 Date: Tue, 27 Feb 2018 13:36:53 +0000
-Subject: [PATCH 2002/2009] jdk: Allow using a system-installed libjpeg
+Subject: [PATCH] jdk: Allow using a system-installed libjpeg
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
 Content-Transfer-Encoding: 8bit
@@ -21,8 +21,9 @@ Issues fixed on top of debian patch:
 Upstream-Status: Backport
 Signed-off-by: André Draszik <andre.draszik@jci.com>
 Signed-off-by: Richard Leitner <richard.leitner@skidata.com>
+
 ---
- make/lib/Awt2dLibraries.gmk                   | 69 +++++++++++++------
+ jdk/make/lib/Awt2dLibraries.gmk               | 69 +++++++++++++------
  .../imageio/plugins/jpeg/JPEGImageReader.java |  2 +-
  .../imageio/plugins/jpeg/JPEGImageWriter.java |  2 +-
  .../sun/awt/image/JPEGImageDecoder.java       |  2 +-
@@ -30,7 +31,7 @@ Signed-off-by: Richard Leitner <richard.leitner@skidata.com>
  5 files changed, 51 insertions(+), 26 deletions(-)
 
 diff --git a/jdk/make/lib/Awt2dLibraries.gmk b/jdk/make/lib/Awt2dLibraries.gmk
-index 9368a9d508..7fffcafc70 100644
+index 9368a9d5..7fffcafc 100644
 --- a/jdk/make/lib/Awt2dLibraries.gmk
 +++ b/jdk/make/lib/Awt2dLibraries.gmk
 @@ -702,21 +702,24 @@ $(BUILD_LIBLCMS): $(BUILD_LIBAWT)
@@ -160,7 +161,7 @@ index 9368a9d508..7fffcafc70 100644
        VERSIONINFO_RESOURCE := $(JDK_TOPDIR)/src/windows/resource/version.rc, \
        RC_FLAGS := $(RC_FLAGS) \
 diff --git a/jdk/src/share/classes/com/sun/imageio/plugins/jpeg/JPEGImageReader.java b/jdk/src/share/classes/com/sun/imageio/plugins/jpeg/JPEGImageReader.java
-index 8f58f5b3e6..fcbab82602 100644
+index 8f58f5b3..fcbab826 100644
 --- a/jdk/src/share/classes/com/sun/imageio/plugins/jpeg/JPEGImageReader.java
 +++ b/jdk/src/share/classes/com/sun/imageio/plugins/jpeg/JPEGImageReader.java
 @@ -89,7 +89,7 @@ public class JPEGImageReader extends ImageReader {
@@ -173,7 +174,7 @@ index 8f58f5b3e6..fcbab82602 100644
                  }
              });
 diff --git a/jdk/src/share/classes/com/sun/imageio/plugins/jpeg/JPEGImageWriter.java b/jdk/src/share/classes/com/sun/imageio/plugins/jpeg/JPEGImageWriter.java
-index 6a33bd5a15..dca189ed85 100644
+index 6a33bd5a..dca189ed 100644
 --- a/jdk/src/share/classes/com/sun/imageio/plugins/jpeg/JPEGImageWriter.java
 +++ b/jdk/src/share/classes/com/sun/imageio/plugins/jpeg/JPEGImageWriter.java
 @@ -177,7 +177,7 @@ public class JPEGImageWriter extends ImageWriter {
@@ -186,7 +187,7 @@ index 6a33bd5a15..dca189ed85 100644
                  }
              });
 diff --git a/jdk/src/share/classes/sun/awt/image/JPEGImageDecoder.java b/jdk/src/share/classes/sun/awt/image/JPEGImageDecoder.java
-index 872ffc0197..5965a186b9 100644
+index 872ffc01..5965a186 100644
 --- a/jdk/src/share/classes/sun/awt/image/JPEGImageDecoder.java
 +++ b/jdk/src/share/classes/sun/awt/image/JPEGImageDecoder.java
 @@ -56,7 +56,7 @@ public class JPEGImageDecoder extends ImageDecoder {
@@ -199,7 +200,7 @@ index 872ffc0197..5965a186b9 100644
                  }
              });
 diff --git a/jdk/src/share/native/sun/awt/image/jpeg/imageioJPEG.c b/jdk/src/share/native/sun/awt/image/jpeg/imageioJPEG.c
-index 7e1d8c99d7..8cac61da32 100644
+index 7e1d8c99..8cac61da 100644
 --- a/jdk/src/share/native/sun/awt/image/jpeg/imageioJPEG.c
 +++ b/jdk/src/share/native/sun/awt/image/jpeg/imageioJPEG.c
 @@ -51,7 +51,7 @@
@@ -211,6 +212,3 @@ index 7e1d8c99d7..8cac61da32 100644
  
  #undef MAX
  #define MAX(a,b)        ((a) > (b) ? (a) : (b))
--- 
-2.26.2
-

--- a/recipes-core/openjdk/patches-openjdk-8/2003-jdk-Allow-using-a-system-installed-libpng.patch
+++ b/recipes-core/openjdk/patches-openjdk-8/2003-jdk-Allow-using-a-system-installed-libpng.patch
@@ -1,7 +1,7 @@
-From c7fb1d599ba66116fb132537b4696092e9c48331 Mon Sep 17 00:00:00 2001
+From ce26d6cbb550039516432993894d65660b7c9e06 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Andr=C3=A9=20Draszik?= <andre.draszik@jci.com>
 Date: Tue, 27 Feb 2018 13:43:04 +0000
-Subject: [PATCH 2003/2009] jdk: Allow using a system-installed libpng
+Subject: [PATCH] jdk: Allow using a system-installed libpng
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
 Content-Transfer-Encoding: 8bit
@@ -18,13 +18,14 @@ Issues fixed on top of debian patch:
 Upstream-Status: Backport
 Signed-off-by: André Draszik <andre.draszik@jci.com>
 Signed-off-by: Richard Leitner <richard.leitner@skidata.com>
+
 ---
- make/lib/Awt2dLibraries.gmk                          | 12 +++++++++---
+ jdk/make/lib/Awt2dLibraries.gmk                      | 12 +++++++++---
  .../native/sun/awt/splashscreen/splashscreen_png.c   |  3 +--
  2 files changed, 10 insertions(+), 5 deletions(-)
 
 diff --git a/jdk/make/lib/Awt2dLibraries.gmk b/jdk/make/lib/Awt2dLibraries.gmk
-index 7fffcafc70..7f42e09ce4 100644
+index 7fffcafc..7f42e09c 100644
 --- a/jdk/make/lib/Awt2dLibraries.gmk
 +++ b/jdk/make/lib/Awt2dLibraries.gmk
 @@ -1155,7 +1155,6 @@ endif
@@ -65,7 +66,7 @@ index 7fffcafc70..7f42e09ce4 100644
        VERSIONINFO_RESOURCE := $(JDK_TOPDIR)/src/windows/resource/version.rc, \
        RC_FLAGS := $(RC_FLAGS) \
 diff --git a/jdk/src/share/native/sun/awt/splashscreen/splashscreen_png.c b/jdk/src/share/native/sun/awt/splashscreen/splashscreen_png.c
-index 3599433e42..5bf002ea17 100644
+index 3599433e..5bf002ea 100644
 --- a/jdk/src/share/native/sun/awt/splashscreen/splashscreen_png.c
 +++ b/jdk/src/share/native/sun/awt/splashscreen/splashscreen_png.c
 @@ -25,8 +25,7 @@
@@ -78,6 +79,3 @@ index 3599433e42..5bf002ea17 100644
  #include <setjmp.h>
  
  #define SIG_BYTES 8
--- 
-2.26.2
-

--- a/recipes-core/openjdk/patches-openjdk-8/2004-jdk-use-correct-include-for-poll.patch
+++ b/recipes-core/openjdk/patches-openjdk-8/2004-jdk-use-correct-include-for-poll.patch
@@ -1,7 +1,7 @@
-From 5bced26833d8e7876852fa65479f7ada5266a3d7 Mon Sep 17 00:00:00 2001
+From 44512cfca65ea5b7b6d1732560d8aa2cd221de22 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Andr=C3=A9=20Draszik?= <andre.draszik@jci.com>
 Date: Tue, 27 Feb 2018 09:28:06 +0000
-Subject: [PATCH 2004/2009] jdk: use correct include for poll
+Subject: [PATCH] jdk: use correct include for poll
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
 Content-Transfer-Encoding: 8bit
@@ -25,21 +25,22 @@ the following command:
 Upstream-Status: Pending
 Signed-off-by: André Draszik <andre.draszik@jci.com>
 Signed-off-by: Richard Leitner <richard.leitner@skidata.com>
+
 ---
- src/aix/native/java/net/aix_close.c                 | 2 +-
- src/aix/native/sun/nio/ch/AixPollPort.c             | 2 +-
- src/solaris/native/java/net/PlainSocketImpl.c       | 2 +-
- src/solaris/native/java/net/bsd_close.c             | 2 +-
- src/solaris/native/java/net/linux_close.c           | 2 +-
- src/solaris/native/java/net/net_util_md.h           | 2 +-
- src/solaris/native/sun/nio/ch/DevPollArrayWrapper.c | 2 +-
- src/solaris/native/sun/nio/ch/Net.c                 | 2 +-
- src/solaris/native/sun/nio/fs/LinuxWatchService.c   | 2 +-
- src/solaris/transport/socket/socket_md.c            | 2 +-
+ jdk/src/aix/native/java/net/aix_close.c                 | 2 +-
+ jdk/src/aix/native/sun/nio/ch/AixPollPort.c             | 2 +-
+ jdk/src/solaris/native/java/net/PlainSocketImpl.c       | 2 +-
+ jdk/src/solaris/native/java/net/bsd_close.c             | 2 +-
+ jdk/src/solaris/native/java/net/linux_close.c           | 2 +-
+ jdk/src/solaris/native/java/net/net_util_md.h           | 2 +-
+ jdk/src/solaris/native/sun/nio/ch/DevPollArrayWrapper.c | 2 +-
+ jdk/src/solaris/native/sun/nio/ch/Net.c                 | 2 +-
+ jdk/src/solaris/native/sun/nio/fs/LinuxWatchService.c   | 2 +-
+ jdk/src/solaris/transport/socket/socket_md.c            | 2 +-
  10 files changed, 10 insertions(+), 10 deletions(-)
 
 diff --git a/jdk/src/aix/native/java/net/aix_close.c b/jdk/src/aix/native/java/net/aix_close.c
-index 90d57b42f0..fbeb73efa4 100644
+index 90d57b42..fbeb73ef 100644
 --- a/jdk/src/aix/native/java/net/aix_close.c
 +++ b/jdk/src/aix/native/java/net/aix_close.c
 @@ -54,7 +54,7 @@
@@ -52,7 +53,7 @@ index 90d57b42f0..fbeb73efa4 100644
  /*
   * Stack allocated by thread when doing blocking operation
 diff --git a/jdk/src/aix/native/sun/nio/ch/AixPollPort.c b/jdk/src/aix/native/sun/nio/ch/AixPollPort.c
-index 70064b890e..c10c602b6b 100644
+index 70064b89..c10c602b 100644
 --- a/jdk/src/aix/native/sun/nio/ch/AixPollPort.c
 +++ b/jdk/src/aix/native/sun/nio/ch/AixPollPort.c
 @@ -34,7 +34,7 @@
@@ -65,7 +66,7 @@ index 70064b890e..c10c602b6b 100644
  #include <fcntl.h>
  #include <stddef.h>
 diff --git a/jdk/src/solaris/native/java/net/PlainSocketImpl.c b/jdk/src/solaris/native/java/net/PlainSocketImpl.c
-index 373c5e3625..9aafbc09e5 100644
+index 373c5e36..9aafbc09 100644
 --- a/jdk/src/solaris/native/java/net/PlainSocketImpl.c
 +++ b/jdk/src/solaris/native/java/net/PlainSocketImpl.c
 @@ -28,7 +28,7 @@
@@ -78,7 +79,7 @@ index 373c5e3625..9aafbc09e5 100644
  #include <netinet/tcp.h>        /* Defines TCP_NODELAY, needed for 2.6 */
  #include <netinet/in.h>
 diff --git a/jdk/src/solaris/native/java/net/bsd_close.c b/jdk/src/solaris/native/java/net/bsd_close.c
-index 89a20707c4..511ab845a8 100644
+index 89a20707..511ab845 100644
 --- a/jdk/src/solaris/native/java/net/bsd_close.c
 +++ b/jdk/src/solaris/native/java/net/bsd_close.c
 @@ -38,7 +38,7 @@
@@ -91,7 +92,7 @@ index 89a20707c4..511ab845a8 100644
  /*
   * Stack allocated by thread when doing blocking operation
 diff --git a/jdk/src/solaris/native/java/net/linux_close.c b/jdk/src/solaris/native/java/net/linux_close.c
-index eacc2afd15..159ca132c4 100644
+index eacc2afd..159ca132 100644
 --- a/jdk/src/solaris/native/java/net/linux_close.c
 +++ b/jdk/src/solaris/native/java/net/linux_close.c
 @@ -36,7 +36,7 @@
@@ -104,7 +105,7 @@ index eacc2afd15..159ca132c4 100644
  /*
   * Stack allocated by thread when doing blocking operation
 diff --git a/jdk/src/solaris/native/java/net/net_util_md.h b/jdk/src/solaris/native/java/net/net_util_md.h
-index a48446de9c..8915b68aae 100644
+index a48446de..8915b68a 100644
 --- a/jdk/src/solaris/native/java/net/net_util_md.h
 +++ b/jdk/src/solaris/native/java/net/net_util_md.h
 @@ -33,7 +33,7 @@
@@ -117,7 +118,7 @@ index a48446de9c..8915b68aae 100644
  
  
 diff --git a/jdk/src/solaris/native/sun/nio/ch/DevPollArrayWrapper.c b/jdk/src/solaris/native/sun/nio/ch/DevPollArrayWrapper.c
-index 6860a167bb..20849dabcf 100644
+index 6860a167..20849dab 100644
 --- a/jdk/src/solaris/native/sun/nio/ch/DevPollArrayWrapper.c
 +++ b/jdk/src/solaris/native/sun/nio/ch/DevPollArrayWrapper.c
 @@ -28,7 +28,7 @@
@@ -130,7 +131,7 @@ index 6860a167bb..20849dabcf 100644
  #include <sys/time.h>
  
 diff --git a/jdk/src/solaris/native/sun/nio/ch/Net.c b/jdk/src/solaris/native/sun/nio/ch/Net.c
-index 73560ad6c6..a3720055c4 100644
+index 73560ad6..a3720055 100644
 --- a/jdk/src/solaris/native/sun/nio/ch/Net.c
 +++ b/jdk/src/solaris/native/sun/nio/ch/Net.c
 @@ -23,7 +23,7 @@
@@ -143,7 +144,7 @@ index 73560ad6c6..a3720055c4 100644
  #include <sys/socket.h>
  #include <string.h>
 diff --git a/jdk/src/solaris/native/sun/nio/fs/LinuxWatchService.c b/jdk/src/solaris/native/sun/nio/fs/LinuxWatchService.c
-index 375aaa4850..7606e9ba82 100644
+index 375aaa48..7606e9ba 100644
 --- a/jdk/src/solaris/native/sun/nio/fs/LinuxWatchService.c
 +++ b/jdk/src/solaris/native/sun/nio/fs/LinuxWatchService.c
 @@ -32,7 +32,7 @@
@@ -156,7 +157,7 @@ index 375aaa4850..7606e9ba82 100644
  
  #include "sun_nio_fs_LinuxWatchService.h"
 diff --git a/jdk/src/solaris/transport/socket/socket_md.c b/jdk/src/solaris/transport/socket/socket_md.c
-index 33e062e087..819fcabdb8 100644
+index 33e062e0..819fcabd 100644
 --- a/jdk/src/solaris/transport/socket/socket_md.c
 +++ b/jdk/src/solaris/transport/socket/socket_md.c
 @@ -37,7 +37,7 @@
@@ -168,6 +169,3 @@ index 33e062e087..819fcabdb8 100644
  #endif
  
  #include "socket_md.h"
--- 
-2.26.2
-

--- a/recipes-core/openjdk/patches-openjdk-8/2005-jdk-use-correct-include-for-signal.patch
+++ b/recipes-core/openjdk/patches-openjdk-8/2005-jdk-use-correct-include-for-signal.patch
@@ -1,7 +1,7 @@
-From 385b2007a60c3e792062107d3c4f653fe63d4c63 Mon Sep 17 00:00:00 2001
+From ddcec385593175ee01b9f000457a34b3d7ab5ab4 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Andr=C3=A9=20Draszik?= <andre.draszik@jci.com>
 Date: Tue, 27 Feb 2018 09:28:06 +0000
-Subject: [PATCH 2005/2009] jdk: use correct include for signal
+Subject: [PATCH] jdk: use correct include for signal
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
 Content-Transfer-Encoding: 8bit
@@ -26,15 +26,16 @@ the following command:
 Upstream-Status: Pending
 Signed-off-by: André Draszik <andre.draszik@jci.com>
 Signed-off-by: Richard Leitner <richard.leitner@skidata.com>
+
 ---
- src/aix/native/sun/nio/ch/AixNativeThread.c  | 2 +-
- src/macosx/javavm/export/jvm_md.h            | 2 +-
- src/solaris/javavm/export/jvm_md.h           | 2 +-
- src/solaris/native/sun/nio/ch/NativeThread.c | 2 +-
+ jdk/src/aix/native/sun/nio/ch/AixNativeThread.c  | 2 +-
+ jdk/src/macosx/javavm/export/jvm_md.h            | 2 +-
+ jdk/src/solaris/javavm/export/jvm_md.h           | 2 +-
+ jdk/src/solaris/native/sun/nio/ch/NativeThread.c | 2 +-
  4 files changed, 4 insertions(+), 4 deletions(-)
 
 diff --git a/jdk/src/aix/native/sun/nio/ch/AixNativeThread.c b/jdk/src/aix/native/sun/nio/ch/AixNativeThread.c
-index c0d5857962..c4abb7ae5d 100644
+index c0d58579..c4abb7ae 100644
 --- a/jdk/src/aix/native/sun/nio/ch/AixNativeThread.c
 +++ b/jdk/src/aix/native/sun/nio/ch/AixNativeThread.c
 @@ -32,7 +32,7 @@
@@ -47,7 +48,7 @@ index c0d5857962..c4abb7ae5d 100644
  /* Also defined in src/aix/native/java/net/aix_close.c */
  #define INTERRUPT_SIGNAL (SIGRTMAX - 1)
 diff --git a/jdk/src/macosx/javavm/export/jvm_md.h b/jdk/src/macosx/javavm/export/jvm_md.h
-index 012bb1babe..0b57576833 100644
+index 012bb1ba..0b575768 100644
 --- a/jdk/src/macosx/javavm/export/jvm_md.h
 +++ b/jdk/src/macosx/javavm/export/jvm_md.h
 @@ -60,7 +60,7 @@
@@ -60,7 +61,7 @@ index 012bb1babe..0b57576833 100644
  /* O Flags */
  
 diff --git a/jdk/src/solaris/javavm/export/jvm_md.h b/jdk/src/solaris/javavm/export/jvm_md.h
-index 5c681914bb..62415ee255 100644
+index 5c681914..62415ee2 100644
 --- a/jdk/src/solaris/javavm/export/jvm_md.h
 +++ b/jdk/src/solaris/javavm/export/jvm_md.h
 @@ -65,7 +65,7 @@
@@ -73,7 +74,7 @@ index 5c681914bb..62415ee255 100644
  /* O Flags */
  
 diff --git a/jdk/src/solaris/native/sun/nio/ch/NativeThread.c b/jdk/src/solaris/native/sun/nio/ch/NativeThread.c
-index 5e2a78b7af..204f0441a9 100644
+index 5e2a78b7..204f0441 100644
 --- a/jdk/src/solaris/native/sun/nio/ch/NativeThread.c
 +++ b/jdk/src/solaris/native/sun/nio/ch/NativeThread.c
 @@ -34,7 +34,7 @@
@@ -85,6 +86,3 @@ index 5e2a78b7af..204f0441a9 100644
    /* Also defined in net/linux_close.c */
    #define INTERRUPT_SIGNAL (__SIGRTMAX - 2)
  #elif __solaris__
--- 
-2.26.2
-

--- a/recipes-core/openjdk/patches-openjdk-8/2006-jdk-disable-backtrace-musl-build-fix.patch
+++ b/recipes-core/openjdk/patches-openjdk-8/2006-jdk-disable-backtrace-musl-build-fix.patch
@@ -1,7 +1,7 @@
-From 80a07db16d9de0cd875b9c8e86678a51b6e75dbf Mon Sep 17 00:00:00 2001
+From f27d54f62c5a5667c04b78ea1434a5db36358261 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Andr=C3=A9=20Draszik?= <andre.draszik@jci.com>
 Date: Fri, 2 Mar 2018 13:58:07 +0000
-Subject: [PATCH 2006/2009] jdk: disable backtrace() (musl build fix)
+Subject: [PATCH] jdk: disable backtrace() (musl build fix)
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
 Content-Transfer-Encoding: 8bit
@@ -15,12 +15,13 @@ to fix the build on musl.
 Upstream-Status: Pending
 Signed-off-by: André Draszik <andre.draszik@jci.com>
 Signed-off-by: Richard Leitner <richard.leitner@skidata.com>
+
 ---
- src/solaris/native/sun/xawt/XToolkit.c | 4 ++--
+ jdk/src/solaris/native/sun/xawt/XToolkit.c | 4 ++--
  1 file changed, 2 insertions(+), 2 deletions(-)
 
 diff --git a/jdk/src/solaris/native/sun/xawt/XToolkit.c b/jdk/src/solaris/native/sun/xawt/XToolkit.c
-index 95d2baff5b..41dfa992a7 100644
+index 95d2baff..41dfa992 100644
 --- a/jdk/src/solaris/native/sun/xawt/XToolkit.c
 +++ b/jdk/src/solaris/native/sun/xawt/XToolkit.c
 @@ -27,7 +27,7 @@
@@ -41,6 +42,3 @@ index 95d2baff5b..41dfa992a7 100644
  void print_stack(void)
  {
    void *array[10];
--- 
-2.26.2
-

--- a/recipes-core/openjdk/patches-openjdk-8/2007-jdk-no-genx11-in-headless.patch
+++ b/recipes-core/openjdk/patches-openjdk-8/2007-jdk-no-genx11-in-headless.patch
@@ -1,15 +1,16 @@
-From 6f76fb04370713bdae2485261d987448c9350179 Mon Sep 17 00:00:00 2001
+From 095da0fd8597f0ed8d95d226300e8d6661ac2383 Mon Sep 17 00:00:00 2001
 From: Jens Rehsack <rehsack@gmail.com>
 Date: Thu, 2 Jan 2020 13:25:12 +0100
-Subject: [PATCH 2007/2009] jdk: no genx11 in headless
+Subject: [PATCH] jdk: no genx11 in headless
 
 Signed-off-by: Richard Leitner <richard.leitner@skidata.com>
+
 ---
- make/GenerateSources.gmk | 8 +++++---
+ jdk/make/GenerateSources.gmk | 8 +++++---
  1 file changed, 5 insertions(+), 3 deletions(-)
 
 diff --git a/jdk/make/GenerateSources.gmk b/jdk/make/GenerateSources.gmk
-index ba443f7da5..2170150aca 100644
+index ba443f7d..2170150a 100644
 --- a/jdk/make/GenerateSources.gmk
 +++ b/jdk/make/GenerateSources.gmk
 @@ -73,9 +73,11 @@ ifneq ($(OPENJDK_TARGET_OS), windows)
@@ -27,6 +28,3 @@ index ba443f7da5..2170150aca 100644
    endif
  endif
  
--- 
-2.26.2
-

--- a/recipes-core/openjdk/patches-openjdk-8/2008-jdk-no-unused-deps.patch
+++ b/recipes-core/openjdk/patches-openjdk-8/2008-jdk-no-unused-deps.patch
@@ -1,18 +1,19 @@
-From 335f9891be66e1292509d6a9dc18d41fac0a066c Mon Sep 17 00:00:00 2001
+From bc6450aaa4b7652ee034423f1d04cb439152eaf6 Mon Sep 17 00:00:00 2001
 From: Jens Rehsack <rehsack@gmail.com>
 Date: Thu, 2 Jan 2020 13:26:42 +0100
-Subject: [PATCH 2008/2009] jdk: no unused deps
+Subject: [PATCH] jdk: no unused deps
 
 Signed-off-by: Richard Leitner <richard.leitner@skidata.com>
+
 ---
- make/CompileNativeLibraries.gmk           |  2 ++
- make/lib/Awt2dLibraries.gmk               | 30 +++++++++++++++++------
- src/solaris/native/sun/awt/jawt.c         |  2 +-
- src/solaris/native/sun/awt/utility/rect.h |  2 +-
+ jdk/make/CompileNativeLibraries.gmk           |  2 ++
+ jdk/make/lib/Awt2dLibraries.gmk               | 30 ++++++++++++++-----
+ jdk/src/solaris/native/sun/awt/jawt.c         |  2 +-
+ jdk/src/solaris/native/sun/awt/utility/rect.h |  2 +-
  4 files changed, 26 insertions(+), 10 deletions(-)
 
 diff --git a/jdk/make/CompileNativeLibraries.gmk b/jdk/make/CompileNativeLibraries.gmk
-index c23b958b06..2984302f0a 100644
+index c23b958b..2984302f 100644
 --- a/jdk/make/CompileNativeLibraries.gmk
 +++ b/jdk/make/CompileNativeLibraries.gmk
 @@ -85,7 +85,9 @@ include lib/ServiceabilityLibraries.gmk
@@ -26,7 +27,7 @@ index c23b958b06..2984302f0a 100644
  # Include the corresponding custom file, if present. 
  -include $(CUSTOM_MAKE_DIR)/CompileNativeLibraries.gmk
 diff --git a/jdk/make/lib/Awt2dLibraries.gmk b/jdk/make/lib/Awt2dLibraries.gmk
-index 7f42e09ce4..10232b61ca 100644
+index 7f42e09c..10232b61 100644
 --- a/jdk/make/lib/Awt2dLibraries.gmk
 +++ b/jdk/make/lib/Awt2dLibraries.gmk
 @@ -232,6 +232,10 @@ ifeq ($(OPENJDK_TARGET_OS), aix)
@@ -88,7 +89,7 @@ index 7f42e09ce4..10232b61ca 100644
      LIBAWT_HEADLESS_REORDER :=
      ifeq ($(OPENJDK_TARGET_OS), solaris)
 diff --git a/jdk/src/solaris/native/sun/awt/jawt.c b/jdk/src/solaris/native/sun/awt/jawt.c
-index 64284bc6e9..b3584c7efe 100644
+index 64284bc6..b3584c7e 100644
 --- a/jdk/src/solaris/native/sun/awt/jawt.c
 +++ b/jdk/src/solaris/native/sun/awt/jawt.c
 @@ -33,7 +33,7 @@
@@ -101,7 +102,7 @@ index 64284bc6e9..b3584c7efe 100644
      return JNI_FALSE;
  #else
 diff --git a/jdk/src/solaris/native/sun/awt/utility/rect.h b/jdk/src/solaris/native/sun/awt/utility/rect.h
-index ceea38f434..8d85782ba0 100644
+index ceea38f4..8d85782b 100644
 --- a/jdk/src/solaris/native/sun/awt/utility/rect.h
 +++ b/jdk/src/solaris/native/sun/awt/utility/rect.h
 @@ -28,7 +28,7 @@
@@ -113,6 +114,3 @@ index ceea38f434..8d85782ba0 100644
  #include <X11/Xlib.h>
  typedef XRectangle RECT_T;
  #else
--- 
-2.26.2
-

--- a/recipes-core/openjdk/patches-openjdk-8/2009-jdk-make-use-gcc-instead-of-ld-for-genSocketOptionRe.patch
+++ b/recipes-core/openjdk/patches-openjdk-8/2009-jdk-make-use-gcc-instead-of-ld-for-genSocketOptionRe.patch
@@ -1,18 +1,18 @@
-From 2d5e8ce975fb241a825dbf070923ccbdf8b65ee9 Mon Sep 17 00:00:00 2001
+From 83d3b8427c8996f3a0359d218f174b46fe9120c8 Mon Sep 17 00:00:00 2001
 From: Richard Leitner <richard.leitner@skidata.com>
 Date: Thu, 20 Aug 2020 11:24:40 +0200
-Subject: [PATCH 2009/2009] jdk: make: use gcc instead of ld for
- genSocketOptionRegistry
+Subject: [PATCH] jdk: make: use gcc instead of ld for genSocketOptionRegistry
 
 Upstream-Status: Pending
 
 Signed-off-by: Richard Leitner <richard.leitner@skidata.com>
+
 ---
- make/gensrc/GensrcMisc.gmk | 2 +-
+ jdk/make/gensrc/GensrcMisc.gmk | 2 +-
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/jdk/make/gensrc/GensrcMisc.gmk b/jdk/make/gensrc/GensrcMisc.gmk
-index 9db5c9d6f7..84a3c27e7d 100644
+index 9db5c9d6..84a3c27e 100644
 --- a/jdk/make/gensrc/GensrcMisc.gmk
 +++ b/jdk/make/gensrc/GensrcMisc.gmk
 @@ -76,7 +76,7 @@ $(eval $(call SetupNativeCompilation,BUILD_GENSRC_SOR_EXE, \
@@ -24,6 +24,3 @@ index 9db5c9d6f7..84a3c27e7d 100644
      OBJECT_DIR := $(GENSRC_SOR_BIN), \
      OUTPUT_DIR := $(GENSRC_SOR_BIN), \
      PROGRAM := genSocketOptionRegistry))
--- 
-2.26.2
-


### PR DESCRIPTION
Yocto 4.2 bitbake is more pedantic on patch fuzz, which treats patch fuzz Warnings as Errors, and fails the bulid.

Corrected patch fuzz with:

    devtool modify openjdk-8-native
    devtool finish --force-patch-refresh openjdk-8-native <meta-java layer_path>

but removed the changes to 1001-hotspot-fix-crash-on-JNI_CreateJavaVM.patch which rewrote a huge amount of source files in their entirety for some reason.