### PR TITLE
Fix rhino download link

### DIFF
--- a/recipes-core/rhino/rhino_1.7r4.bb
+++ b/recipes-core/rhino/rhino_1.7r4.bb
@@ -11,12 +11,12 @@ PACKAGE_ARCH = "${TUNE_PKGARCH}"
 inherit java-library
 
 SRC_URI = "\
-	https://github.com/downloads/mozilla/rhino/rhino1_7R4.zip \
+	https://github.com/mozilla/rhino/archive/refs/tags/Rhino1_7R4_RELEASE.zip \
 	file://rhino \
 	file://rhino-jsc \
 	"
 
-S = "${WORKDIR}/rhino1_7R4"
+S = "${WORKDIR}/rhino-Rhino1_7R4_RELEASE"
 
 PACKAGES = "${JPN} rhino"
 
@@ -46,5 +46,5 @@ do_install:append() {
 	install -m 0755 ${WORKDIR}/rhino-jsc ${D}${bindir}
 }
 
-SRC_URI[md5sum] = "ad67a3dff135e3a70f0c3528a2d6edf2"
-SRC_URI[sha256sum] = "9eb08f85bbe7c8e0b9eaffb1cf4984b31fb679f3c8a682acc3bb8ac20626c61e"
+SRC_URI[md5sum] = "1f893577269631703d31e4de9d5dc1f4"
+SRC_URI[sha256sum] = "860965fc611764745b3a4fc5bd4baac07356a9fedd2ce6642e7bb0bd7ef58d07"


### PR DESCRIPTION
Updated to use the archive download link per https://github.com/meta-java/meta-java/issues/4#issuecomment-1551182838. 

Build succeeds, but generates a QA warning: `WARNING: rhino-1.7r4-r0 do_unpack: QA Issue: rhino: SRC_URI uses unstable GitHub/GitLab archives, convert recipe to use git protocol [src-uri-bad]`

Any ideas on more stable sources @g0hl1n if that'll be a problem?