### PR TITLE
xerces-j: update SRC_URI

### DIFF
--- a/recipes-core/xerces-j/xerces-j_2.11.0.bb
+++ b/recipes-core/xerces-j/xerces-j_2.11.0.bb
@@ -12,7 +12,7 @@ LIC_FILES_CHKSUM = " \
                     file://LICENSE.serializer.txt;md5=d229da563da18fe5d58cd95a6467d584 \
                    "
 
-SRC_URI = "http://archive.apache.org/dist/xerces/j/Xerces-J-src.${PV}.tar.gz"
+SRC_URI = "http://archive.apache.org/dist/xerces/j/source/Xerces-J-src.${PV}.tar.gz"
 
 # CVE only applies to some Oracle Java SE and Red Hat Enterprise Linux versions.
 # Already fixed with updates and closed.


### PR DESCRIPTION
dunfell branch has a same problem about archive URL.
so, I cherry-pick patch from kirkstone(87dd00a5b17ab020ee3415556a17c4451092c7fd)

The archive URL has changed slightly, add missing /source/.
https://archive.apache.org/dist/xerces/j/source/

