### PR TITLE
[kirkstone] Backport pkgconfig for classpath kirkstone

### DIFF
--- a/recipes-core/classpath/classpath.inc
+++ b/recipes-core/classpath/classpath.inc
@@ -7,7 +7,7 @@ LICENSE = "GPL-2.0 & SAX-PD"
 
 PBN = "classpath"
 
-inherit autotools java gettext
+inherit autotools pkgconfig java gettext
 
 DEPENDS = "virtual/javac-native fastjar-native zip-native gmp antlr-native gtk+ gconf libxtst file"
 


### PR DESCRIPTION
Building with Kirkstone 4.0.14 fails with the same error as given in the original commit message. Adding `pkgconfig` as a dependency fixes this.

The dependency is already present in Mickledore and there is no branch for Nanbield. So no further backports are needed at a first glance.