### PR TITLE
Added compatibility with GCC 12.x (Kas 4.2 and Yocto 4.3.2).

### DIFF
--- a/recipes-core/icedtea/icedtea7-native.inc
+++ b/recipes-core/icedtea/icedtea7-native.inc
@@ -21,9 +21,8 @@ CFLAGS:append = "${@bb.utils.contains('PACKAGECONFIG', 'x11', '', ' -DHEADLESS=t
 # Disable dead store elimination and set C++ standard to C++98.
 # There are dead stores in the JVM that would be pretty hard to
 # remove, so disable the optimisation in the compiler.
-CFLAGS:append = " -fno-tree-dse"
-CXXFLAGS:append = " -fno-tree-dse"
-CXX:append = " -std=gnu++98"
+CFLAGS:append = " -std=gnu++98 -fno-tree-dse -fno-tree-vectorize"
+CXXFLAGS:append = " -std=gnu++98 -fno-tree-dse"
 
 # WORKAROUND: ignore errors from new compilers
 CFLAGS:append = " -Wno-error=stringop-overflow -Wno-error=return-type"

--- a/recipes-core/openjdk/openjdk-7-common.inc
+++ b/recipes-core/openjdk/openjdk-7-common.inc
@@ -459,3 +459,6 @@ ALTERNATIVE_LINK_NAME[javac] = "${bindir}/javac"
 ALTERNATIVE_LINK_NAME[keytool] = "${bindir}/keytool"
 
 ALTERNATIVE_PRIORITY = "50"
+
+# canon-prefix-map doesn't exist in gcc 12.x
+DEBUG_PREFIX_MAP:remove = "-fcanon-prefix-map"

--- a/recipes-core/openjdk/openjdk-8-common.inc
+++ b/recipes-core/openjdk/openjdk-8-common.inc
@@ -194,3 +194,6 @@ BUILD_CXXFLAGS:append = " ${GLOBAL_FLAGS}"
 # flags for -cross
 TARGET_CFLAGS:append = " ${GLOBAL_FLAGS}"
 TARGET_CXXFLAGS:append = " ${GLOBAL_FLAGS}"
+
+# canon-prefix-map doesn't exist in gcc 12.x
+DEBUG_PREFIX_MAP:remove = "-fcanon-prefix-map"


### PR DESCRIPTION
The patch makes fixes for compatibility with GCC 12.x which used in kas 4.0 and later.