### PR TITLE
[master][nanbield] jsch,xerces-j: fix deprecated CVE_CHECK_IGNORE

### DIFF
--- a/recipes-core/jcraft/jsch_0.1.40.bb
+++ b/recipes-core/jcraft/jsch_0.1.40.bb
@@ -26,7 +26,7 @@ SRC_URI[md5sum] = "b59cec19a487e95aed68378976b4b566"
 SRC_URI[sha256sum] = "ca9d2ae08fd7a8983fb00d04f0f0c216a985218a5eb364ff9bee73870f28e097"
 
 # Ignore the CVE because it only affects Windows platforms
-CVE_CHECK_IGNORE += "CVE-2016-5725"
+CVE_STATUS += "CVE-2016-5725"
 
 BBCLASSEXTEND = "native"
 

--- a/recipes-core/xerces-j/xerces-j_2.11.0.bb
+++ b/recipes-core/xerces-j/xerces-j_2.11.0.bb
@@ -18,7 +18,7 @@ SRC_URI = "http://archive.apache.org/dist/xerces/j/source/Xerces-J-src.${PV}.tar
 # Already fixed with updates and closed.
 # https://access.redhat.com/security/cve/CVE-2018-2799
 # https://bugzilla.redhat.com/show_bug.cgi?id=1567542
-CVE_CHECK_IGNORE += "CVE-2018-2799"
+CVE_STATUS += "CVE-2018-2799"
 
 S = "${WORKDIR}/xerces-2_11_0"
 


### PR DESCRIPTION
The preferred variable name is now CVE_STATUS since:

openembedded-core 34f682a24b7075b12ec308154b937ad118d69fe5 "cve-check: add option to add additional patched CVEs"

Fixes:
WARNING: /build/../meta-java/recipes-core/jcraft/jsch_0.1.40.bb:
         CVE_CHECK_IGNORE is deprecated in favor of CVE_STATUS
WARNING: /build/../meta-java/recipes-core/xerces-j/xerces-j_2.11.0.bb:
         CVE_CHECK_IGNORE is deprecated in favor of CVE_STATUS